### PR TITLE
Vehicles and Misc

### DIFF
--- a/EnhancedNativeTrainer/src/features/vehicles.cpp
+++ b/EnhancedNativeTrainer/src/features/vehicles.cpp
@@ -667,10 +667,11 @@ void update_vehicle_features(BOOL bPlayerExists, Ped playerPed)
 						break;
 				}
 			}
-			else if (ENTITY::IS_ENTITY_IN_AIR(veh) || speed > 2.0f)
-				{
-					VEHICLE::SET_VEHICLE_FORWARD_SPEED(veh, 0.0f);
-				}
+			else{
+				VEHICLE::SET_VEHICLE_FORWARD_SPEED(veh, 0.0f);
+				Vector3 rotation = ENTITY::GET_ENTITY_ROTATION(veh, 0);
+				ENTITY::SET_ENTITY_ROTATION(veh, rotation.x, rotation.y, rotation.z, 0, 0);
+			}
 		}
 	}
 	//Lock player vehicle doors


### PR DESCRIPTION
Major
- Additions
  - Added the option to freeze the radio to a specific station.
    - The setting is saved to the database and so it is persistent across sessions.

Minor
- Changes
  - Changed the behavior of the speed boost.
    - When force-stopping the vehicle, it now stops the vehicle's rotation as well.
    - When force-stopping the vehicle, it takes effect no matter how slowly the vehicle is moving (previously did nothing at low speeds).