### PR TITLE
Bodyguards and Weapons

### DIFF
--- a/EnhancedNativeTrainer/src/features/area_effect.cpp
+++ b/EnhancedNativeTrainer/src/features/area_effect.cpp
@@ -69,30 +69,28 @@ std::set<Vehicle> releasedVehicles;
 bool featureShowDebugInfo = false;
 bool featureShowDebugInfoUpdated = false;
 
-void add_areaeffect_feature_enablements(std::vector<FeatureEnabledLocalDefinition>* results)
-{
-	results->push_back(FeatureEnabledLocalDefinition{ "featurePlayerIgnoredByAll", &featurePlayerIgnoredByAll, &featurePlayerIgnoredByAllUpdated });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaPedsInvincible", &featureAreaPedsInvincible, &featureAreaPedsInvincibleUpdated });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaPedsHeadExplode", &featureAreaPedsHeadExplode });
+void add_areaeffect_feature_enablements(std::vector<FeatureEnabledLocalDefinition>* results){
+	results->push_back(FeatureEnabledLocalDefinition{"featurePlayerIgnoredByAll", &featurePlayerIgnoredByAll, &featurePlayerIgnoredByAllUpdated});
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaPedsInvincible", &featureAreaPedsInvincible, &featureAreaPedsInvincibleUpdated});
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaPedsHeadExplode", &featureAreaPedsHeadExplode});
 
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaVehiclesInvincible", &featureAreaVehiclesInvincible, &featureAreaVehiclesInvincibleUpdated });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaVehiclesBroken", &featureAreaVehiclesBroken, &featureAreaVehiclesBrokenUpdated });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaVehiclesExploded", &featureAreaVehiclesExploded });
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaVehiclesInvincible", &featureAreaVehiclesInvincible, &featureAreaVehiclesInvincibleUpdated});
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaVehiclesBroken", &featureAreaVehiclesBroken, &featureAreaVehiclesBrokenUpdated});
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaVehiclesExploded", &featureAreaVehiclesExploded});
 
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAreaPedsRioting", &featureAreaPedsRioting, &featureAreaPedsRiotingUpdated });
+	results->push_back(FeatureEnabledLocalDefinition{"featureAreaPedsRioting", &featureAreaPedsRioting, &featureAreaPedsRiotingUpdated});
 
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAngryPedsUseCover", &featureAngryPedsUseCover });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureAngryPedsTargetYou", &featureAngryPedsTargetYou });
+	results->push_back(FeatureEnabledLocalDefinition{"featureAngryPedsUseCover", &featureAngryPedsUseCover});
+	results->push_back(FeatureEnabledLocalDefinition{"featureAngryPedsTargetYou", &featureAngryPedsTargetYou});
 
-	results->push_back(FeatureEnabledLocalDefinition{ "featurePedsIncludeDrivers", &featurePedsIncludeDrivers });
-	results->push_back(FeatureEnabledLocalDefinition{ "featurePedsIncludePilots", &featurePedsIncludePilots });
+	results->push_back(FeatureEnabledLocalDefinition{"featurePedsIncludeDrivers", &featurePedsIncludeDrivers});
+	results->push_back(FeatureEnabledLocalDefinition{"featurePedsIncludePilots", &featurePedsIncludePilots});
 
-	results->push_back(FeatureEnabledLocalDefinition{ "featureShowDebugInfo", &featureShowDebugInfo, &featureShowDebugInfoUpdated });
+	results->push_back(FeatureEnabledLocalDefinition{"featureShowDebugInfo", &featureShowDebugInfo, &featureShowDebugInfoUpdated});
 
 }
 
-void reset_areaeffect_globals()
-{
+void reset_areaeffect_globals(){
 	featurePlayerIgnoredByAll = false;
 	featurePlayerIgnoredByAllUpdated = true;
 
@@ -121,8 +119,7 @@ void reset_areaeffect_globals()
 	pedWeaponSetIndex = 0;
 }
 
-void process_areaeffect_peds_menu()
-{
+void process_areaeffect_peds_menu(){
 	std::vector<MenuItem<int>*> menuItems;
 
 	ToggleMenuItem<int> *togItem = new ToggleMenuItem<int>();
@@ -170,8 +167,7 @@ void process_areaeffect_peds_menu()
 	draw_generic_menu<int>(menuItems, &areaeffect_ped_level_menu_index, "Ped Effects", onconfirm_areaeffect_ped_menu, NULL, NULL);
 }
 
-void process_areaeffect_vehicle_menu()
-{
+void process_areaeffect_vehicle_menu(){
 	std::vector<MenuItem<int>*> menuItems;
 
 	ToggleMenuItem<int> *togItem = new ToggleMenuItem<int>();
@@ -198,8 +194,7 @@ void process_areaeffect_vehicle_menu()
 	draw_generic_menu<int>(menuItems, &areaeffect_veh_level_menu_index, "Vehicle Effects", NULL, NULL, NULL);
 }
 
-void process_areaeffect_advanced_ped_menu()
-{
+void process_areaeffect_advanced_ped_menu(){
 	std::vector<MenuItem<int>*> menuItems;
 
 	ToggleMenuItem<int> *togItem = new ToggleMenuItem<int>();
@@ -233,33 +228,29 @@ void process_areaeffect_advanced_ped_menu()
 	draw_generic_menu<int>(menuItems, &areaeffect_ped_advconfig_menu_index, "Advanced Ped Config", NULL, NULL, NULL);
 }
 
-bool onconfirm_areaeffect_ped_menu(MenuItem<int> choice)
-{
-	if (choice.value == 1) //advance options
+bool onconfirm_areaeffect_ped_menu(MenuItem<int> choice){
+	if(choice.value == 1) //advance options
 	{
 		process_areaeffect_advanced_ped_menu();
 	}
 	return false;
 }
 
-bool onconfirm_areaeffect_menu(MenuItem<int> choice)
-{
-	switch (choice.value)
-	{
-	case -1:
-		process_areaeffect_peds_menu();
-		break;
-	case -2:
-		process_areaeffect_vehicle_menu();
-		break;
+bool onconfirm_areaeffect_menu(MenuItem<int> choice){
+	switch(choice.value){
+		case -1:
+			process_areaeffect_peds_menu();
+			break;
+		case -2:
+			process_areaeffect_vehicle_menu();
+			break;
 	}
 	return false;
 }
 
-void process_areaeffect_menu()
-{
+void process_areaeffect_menu(){
 	std::vector<MenuItem<int>*> menuItems;
-	
+
 	MenuItem<int> *item = new MenuItem<int>();
 	item->caption = "Pedestrians";
 	item->value = -1;
@@ -284,42 +275,34 @@ void process_areaeffect_menu()
 	//		{ "Everyone Ignores You", &featurePlayerIgnoredByAll, &featurePlayerIgnoredByAllUpdated, true },
 }
 
-void do_maintenance_on_tracked_entities()
-{
-	for each (ENTTrackedPedestrian* tped in trackedPeds)
-	{
+void do_maintenance_on_tracked_entities(){
+	for each (ENTTrackedPedestrian* tped in trackedPeds){
 		//only apply this on average every 20 frames to save effort
 		int randNum = rand() % 20;
-		if (tped->angryApplied && randNum == 1)
-		{
+		if(tped->angryApplied && randNum == 1){
 			findRandomTargetForPed(tped);
 		}
 	}
 }
 
-void findRandomTargetForPed(ENTTrackedPedestrian* tped)
-{
+void findRandomTargetForPed(ENTTrackedPedestrian* tped){
 	Ped otherPed = 0;
-	if (tped->lastTarget == 0 || !ENTITY::DOES_ENTITY_EXIST(tped->lastTarget) || ENTITY::IS_ENTITY_DEAD(tped->lastTarget))
-	{
+	if(tped->lastTarget == 0 || !ENTITY::DOES_ENTITY_EXIST(tped->lastTarget) || ENTITY::IS_ENTITY_DEAD(tped->lastTarget)){
 		tped->lastTarget = 0;
-		while (tped->lastTarget == 0)
-		{
+		while(tped->lastTarget == 0){
 			int randIndex = rand() % (trackedPeds.size() + 1); //add one to the random range
 			randIndex--;
-			if (randIndex < 0 || featureAngryPedsTargetYou) //chance of fighting the player
+			if(randIndex < 0 || featureAngryPedsTargetYou) //chance of fighting the player
 			{
 				otherPed = PLAYER::PLAYER_PED_ID();
 				PED::SET_PED_AS_ENEMY(otherPed, true);
 			}
-			else
-			{
+			else{
 				otherPed = trackedPeds.at(randIndex)->ped;
 			}
 
 			//if we've found ourselves
-			if (otherPed == tped->ped)
-			{
+			if(otherPed == tped->ped){
 				continue;
 			}
 
@@ -330,8 +313,7 @@ void findRandomTargetForPed(ENTTrackedPedestrian* tped)
 	}
 }
 
-void update_area_effects(Ped playerPed)
-{
+void update_area_effects(Ped playerPed){
 	//callsPerFrame = 0;
 
 	allWorldVehiclesThisFrameFilled = false;
@@ -345,26 +327,21 @@ void update_area_effects(Ped playerPed)
 	clear_up_missionised_entitities();
 
 	do_maintenance_on_tracked_entities();
-	
+
 	// everyone ignores player
-	if (featurePlayerIgnoredByAll)
-	{
-		if (bPlayerExists)
-		{
+	if(featurePlayerIgnoredByAll){
+		if(bPlayerExists){
 			PLAYER::SET_POLICE_IGNORE_PLAYER(player, true);
 			PLAYER::SET_EVERYONE_IGNORE_PLAYER(player, true);
 			PLAYER::SET_PLAYER_CAN_BE_HASSLED_BY_GANGS(player, false);
 			PLAYER::SET_IGNORE_LOW_PRIORITY_SHOCKING_EVENTS(player, true);
-			if (get_frame_number() % 5 == 0)
-			{
+			if(get_frame_number() % 5 == 0){
 				set_all_nearby_peds_to_calm();
 			}
 		}
 	}
-	else if (featurePlayerIgnoredByAllUpdated)
-	{
-		if (bPlayerExists)
-		{
+	else if(featurePlayerIgnoredByAllUpdated){
+		if(bPlayerExists){
 			PLAYER::SET_POLICE_IGNORE_PLAYER(player, is_player_ignored_by_police());
 			PLAYER::SET_EVERYONE_IGNORE_PLAYER(player, false);
 			PLAYER::SET_PLAYER_CAN_BE_HASSLED_BY_GANGS(player, true);
@@ -373,73 +350,60 @@ void update_area_effects(Ped playerPed)
 		featurePlayerIgnoredByAllUpdated = false;
 	}
 
-	if (featureAreaPedsInvincible || featureAreaPedsInvincibleUpdated)
-	{
-		if (get_frame_number() % 5 == 0)
-		{
+	if(featureAreaPedsInvincible || featureAreaPedsInvincibleUpdated){
+		if(get_frame_number() % 5 == 0){
 			set_all_nearby_peds_to_invincible(featureAreaPedsInvincible);
 			featureAreaPedsInvincibleUpdated = false;
 		}
 	}
 
-	if (featureAreaPedsHeadExplode)
-	{
+	if(featureAreaPedsHeadExplode){
 		kill_all_nearby_peds_continuous();
 	}
 
-	if (featureAreaVehiclesInvincible || featureAreaVehiclesInvincibleUpdated)
-	{
+	if(featureAreaVehiclesInvincible || featureAreaVehiclesInvincibleUpdated){
 		set_all_nearby_vehs_to_invincible(featureAreaVehiclesInvincible, false);
 		featureAreaVehiclesInvincibleUpdated = false;
 	}
 
-	if (featureAreaVehiclesBroken || featureAreaVehiclesBrokenUpdated)
-	{
+	if(featureAreaVehiclesBroken || featureAreaVehiclesBrokenUpdated){
 		set_all_nearby_vehs_to_broken(featureAreaVehiclesBroken);
 		featureAreaVehiclesBrokenUpdated = false;
 	}
 
-	if (featureAreaVehiclesExploded)
-	{
+	if(featureAreaVehiclesExploded){
 		kill_all_nearby_vehicles_continuous();
 	}
 
-	if (featureAreaPedsRioting || featureAreaPedsRiotingUpdated)
-	{
+	if(featureAreaPedsRioting || featureAreaPedsRiotingUpdated){
 		set_all_nearby_peds_to_angry(featureAreaPedsRioting);
 		featureAreaPedsRiotingUpdated = false;
 	}
 
-	if (pedWeaponSetIndex != 0 || pedWeaponSetUpdated)
-	{
+	if(pedWeaponSetIndex != 0 || pedWeaponSetUpdated){
 		give_all_nearby_peds_a_weapon(pedWeaponSetIndex != 0);
 		pedWeaponSetUpdated = false;
 	}
 
-	if (featureShowDebugInfo || featureShowDebugInfoUpdated)
-	{
+	if(featureShowDebugInfo || featureShowDebugInfoUpdated){
 		show_debug_info_on_screen(featureShowDebugInfo);
 		featureShowDebugInfoUpdated = false;
 	}
-		
+
 }
 
-void show_debug_info_on_screen(bool enabled)
-{
+void show_debug_info_on_screen(bool enabled){
 	std::ostringstream ss;
 	ss << "Peds: " << trackedPeds.size() << "; Vehs: " << trackedVehicles.size() << "\nCalls Total: " << callsPerFrame << ", A: " << callsA << ", B: " << callsB << "\nWP: " << allWorldPedsThisFrame.size() << ", WV: " << allWorldVehiclesThisFrame.size();
 	callsPerFrame = 0;
 	set_status_text_centre_screen(ss.str());
 }
 
-void set_all_nearby_peds_to_calm()
-{
+void set_all_nearby_peds_to_calm(){
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
-	for each (Ped xped in peds)
-	{
+	for each (Ped xped in peds){
 		// Only calm down peds if they're NOT in our group (keeps our bodyguards from chilling out and being lazy)
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			PED::SET_BLOCKING_OF_NON_TEMPORARY_EVENTS(xped, true);
 			PED::SET_PED_FLEE_ATTRIBUTES(xped, 0, 0);
 			//PED::SET_PED_COMBAT_ATTRIBUTES(xped, 17, 1);
@@ -447,20 +411,16 @@ void set_all_nearby_peds_to_calm()
 	}
 }
 
-void set_all_nearby_peds_to_invincible(bool enabled)
-{
+void set_all_nearby_peds_to_invincible(bool enabled){
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
-	for each (Ped xped in peds)
-	{
+	for each (Ped xped in peds){
 		// Only apply to non-bodyguards
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			ENTTrackedPedestrian* trackedPed = findOrCreateTrackedPed(xped);
-			if ((enabled && !trackedPed->madeInvincible) || (!enabled && trackedPed->madeInvincible))
-			{
+			if((enabled && !trackedPed->madeInvincible) || (!enabled && trackedPed->madeInvincible)){
 				PED::SET_PED_DIES_WHEN_INJURED(xped, !enabled);
 
-				PED::SET_PED_MAX_HEALTH(xped, enabled ? 10000 : 100 );
+				PED::SET_PED_MAX_HEALTH(xped, enabled ? 10000 : 100);
 				ENTITY::SET_ENTITY_HEALTH(xped, enabled ? 10000 : 100);
 				PED::SET_PED_SUFFERS_CRITICAL_HITS(xped, !enabled);
 
@@ -473,19 +433,15 @@ void set_all_nearby_peds_to_invincible(bool enabled)
 	}
 }
 
-void set_all_nearby_peds_to_angry(bool enabled)
-{
+void set_all_nearby_peds_to_angry(bool enabled){
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
 
-	for each (Ped xped in peds)
-	{
+	for each (Ped xped in peds){
 		// Only apply to non-bodyguards
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			ENTTrackedPedestrian* trackedPed = findOrCreateTrackedPed(xped);
 
-			if (enabled && !trackedPed->angryApplied)
-			{
+			if(enabled && !trackedPed->angryApplied){
 				PED::SET_PED_COMBAT_ATTRIBUTES(xped, 0, featureAngryPedsUseCover ? 1 : 0); //use cover
 
 				PED::SET_PED_COMBAT_ATTRIBUTES(xped, 46, 1); //always fight
@@ -501,8 +457,7 @@ void set_all_nearby_peds_to_angry(bool enabled)
 				trackedPed->angryApplied = true;
 				trackedPed->missionise();
 			}
-			else if(!enabled && trackedPed->angryApplied)
-			{
+			else if(!enabled && trackedPed->angryApplied){
 				//stop them being angry
 				PED::SET_PED_COMBAT_ATTRIBUTES(xped, 0, 0); //use cover
 				PED::SET_PED_COMBAT_ATTRIBUTES(xped, 46, 0); //always fight
@@ -521,20 +476,16 @@ void set_all_nearby_peds_to_angry(bool enabled)
 	}
 }
 
-void set_all_nearby_vehs_to_invincible(bool enabled, bool force)
-{
+void set_all_nearby_vehs_to_invincible(bool enabled, bool force){
 	std::set<Vehicle> vehicles = get_nearby_vehicles(PLAYER::PLAYER_PED_ID());
 
-	for each (Vehicle veh in vehicles)
-	{
+	for each (Vehicle veh in vehicles){
 		int chanceOfSelection = rand() % 5;
-		if (chanceOfSelection != 1 || force)
-		{
+		if(chanceOfSelection != 1 || force){
 			continue;
 		}
 
-		if (PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID()) == veh)
-		{
+		if(PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID()) == veh){
 			continue;
 		}
 
@@ -550,13 +501,11 @@ void set_all_nearby_vehs_to_invincible(bool enabled, bool force)
 		ENTITY::SET_ENTITY_CAN_BE_DAMAGED(veh, !enabled);
 		VEHICLE::SET_VEHICLE_CAN_BE_VISIBLY_DAMAGED(veh, !enabled);
 
-		for (int i = 0; i < 6; i++)
-		{
+		for(int i = 0; i < 6; i++){
 			VEHICLE::_SET_VEHICLE_DOOR_BREAKABLE(veh, i, !enabled); //(Vehicle, doorIndex, isBreakable)
 		}
 
-		if (enabled)
-		{
+		if(enabled){
 			ENTITY::SET_ENTITY_ONLY_DAMAGED_BY_PLAYER(veh, 1);
 
 			VEHICLE::SET_VEHICLE_BODY_HEALTH(veh, 10000.0f);
@@ -564,20 +513,16 @@ void set_all_nearby_vehs_to_invincible(bool enabled, bool force)
 	}
 }
 
-void set_all_nearby_vehs_to_broken(bool enabled)
-{
+void set_all_nearby_vehs_to_broken(bool enabled){
 	std::set<Vehicle> vehicles = get_nearby_vehicles(PLAYER::PLAYER_PED_ID());
 
-	for each (Vehicle veh in vehicles)
-	{
+	for each (Vehicle veh in vehicles){
 		int chanceOfSelection = rand() % 5;
-		if (chanceOfSelection != 1)
-		{
+		if(chanceOfSelection != 1){
 			continue;
 		}
 
-		if (PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID()) == veh)
-		{
+		if(PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID()) == veh){
 			continue;
 		}
 
@@ -585,25 +530,20 @@ void set_all_nearby_vehs_to_broken(bool enabled)
 
 		BOOL isAircraft = VEHICLE::IS_THIS_MODEL_A_HELI(vehModel) || VEHICLE::IS_THIS_MODEL_A_PLANE(vehModel);
 		BOOL isWeird = VEHICLE::IS_THIS_MODEL_A_TRAIN(vehModel) || VEHICLE::IS_THIS_MODEL_A_BOAT(vehModel) || VEHICLE::_IS_THIS_MODEL_A_SUBMERSIBLE(vehModel);
-		if (isAircraft || isWeird)
-		{
+		if(isAircraft || isWeird){
 			continue;
 		}
 
-		if (enabled)
-		{
+		if(enabled){
 			VEHICLE::SET_VEHICLE_ENGINE_ON(veh, false, true);
 			VEHICLE::SET_VEHICLE_UNDRIVEABLE(veh, true);
 
 			Object taskHdl;
 
-			for (int i = -1; i < VEHICLE::GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(veh); i++)
-			{
+			for(int i = -1; i < VEHICLE::GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(veh); i++){
 				Ped passenger = VEHICLE::GET_PED_IN_VEHICLE_SEAT(veh, i);
-				if (ENTITY::DOES_ENTITY_EXIST(passenger))
-				{
-					if (passenger != PLAYER::PLAYER_PED_ID())
-					{
+				if(ENTITY::DOES_ENTITY_EXIST(passenger)){
+					if(passenger != PLAYER::PLAYER_PED_ID()){
 						AI::CLEAR_PED_TASKS(passenger);
 
 						AI::OPEN_SEQUENCE_TASK(&taskHdl);
@@ -617,18 +557,15 @@ void set_all_nearby_vehs_to_broken(bool enabled)
 				}
 			}
 		}
-		else
-		{
+		else{
 			//VEHICLE::SET_VEHICLE_ENGINE_HEALTH(veh, 1000.0f);
 			VEHICLE::SET_VEHICLE_UNDRIVEABLE(veh, false);
 		}
 	}
 }
 
-std::set<Ped> get_nearby_peds(Ped playerPed)
-{
-	if (allWorldPedsThisFrameFilled)
-	{
+std::set<Ped> get_nearby_peds(Ped playerPed){
+	if(allWorldPedsThisFrameFilled){
 		return allWorldPedsThisFrame;
 	}
 
@@ -639,48 +576,39 @@ std::set<Ped> get_nearby_peds(Ped playerPed)
 	callsA = 0;
 	callsB = found;
 
-	for (int i = 0; i < found; i++)
-	{
+	for(int i = 0; i < found; i++){
 		Ped item = peds[i];
 
-		if (releasedPeds.find(item) != releasedPeds.end())
-		{
+		if(releasedPeds.find(item) != releasedPeds.end()){
 			continue;
 		}
 
-		if (ENTITY::IS_ENTITY_DEAD(item))
-		{
+		if(ENTITY::IS_ENTITY_DEAD(item)){
 			continue;
 		}
-		else if (playerPed == item)
-		{
+		else if(playerPed == item){
 			continue;
 		}
-		else if (!PED::IS_PED_HUMAN(item))
-		{
+		else if(!PED::IS_PED_HUMAN(item)){
 			continue;
 		}
-		else if (ENTITY::IS_ENTITY_A_MISSION_ENTITY(item) && !ENTITY::DOES_ENTITY_BELONG_TO_THIS_SCRIPT(item, true))
-		{
+		else if(ENTITY::IS_ENTITY_A_MISSION_ENTITY(item) && !ENTITY::DOES_ENTITY_BELONG_TO_THIS_SCRIPT(item, true)){
 			continue;
 		}
 
 		//filter out drivers/pilots if necessary
-		if ((!featurePedsIncludePilots || !featurePedsIncludeDrivers) && PED::IS_PED_IN_ANY_VEHICLE(item, false))
-		{
+		if((!featurePedsIncludePilots || !featurePedsIncludeDrivers) && PED::IS_PED_IN_ANY_VEHICLE(item, false)){
 			Vehicle veh = PED::GET_VEHICLE_PED_IS_IN(item, false);
 
 			Hash vehModel = ENTITY::GET_ENTITY_MODEL(veh);
 
 			bool isAircraft = VEHICLE::IS_THIS_MODEL_A_HELI(vehModel) || VEHICLE::IS_THIS_MODEL_A_PLANE(vehModel);
-			if (!featurePedsIncludePilots && isAircraft)
-			{
+			if(!featurePedsIncludePilots && isAircraft){
 				continue;
 			}
 
 			bool isWeird = VEHICLE::IS_THIS_MODEL_A_TRAIN(vehModel) || VEHICLE::IS_THIS_MODEL_A_BOAT(vehModel) || VEHICLE::_IS_THIS_MODEL_A_SUBMERSIBLE(vehModel);
-			if (!featurePedsIncludeDrivers && !isAircraft && !isWeird)
-			{
+			if(!featurePedsIncludeDrivers && !isAircraft && !isWeird){
 				continue;
 			}
 		}
@@ -692,10 +620,8 @@ std::set<Ped> get_nearby_peds(Ped playerPed)
 	return allWorldPedsThisFrame;
 }
 
-std::set<Vehicle> get_nearby_vehicles(Ped playerPed)
-{
-	if (allWorldVehiclesThisFrameFilled)
-	{
+std::set<Vehicle> get_nearby_vehicles(Ped playerPed){
+	if(allWorldVehiclesThisFrameFilled){
 		return allWorldVehiclesThisFrame;
 	}
 
@@ -706,28 +632,23 @@ std::set<Vehicle> get_nearby_vehicles(Ped playerPed)
 	Vehicle vehs[ARR_SIZE];
 	int found = worldGetAllVehicles(vehs, ARR_SIZE);
 
-	for (int i = 0; i < found; i++)
-	{
+	for(int i = 0; i < found; i++){
 		Vehicle item = vehs[i];
 
-		if (releasedVehicles.find(item) != releasedVehicles.end())
-		{
+		if(releasedVehicles.find(item) != releasedVehicles.end()){
 			continue;
 		}
 
 		//don't return dead items
-		if (ENTITY::IS_ENTITY_DEAD(item))
-		{
+		if(ENTITY::IS_ENTITY_DEAD(item)){
 			continue;
 		}
 		//don't return the vehicle we're using
-		else if (playerInVehicle && playerVehicle == item)
-		{
+		else if(playerInVehicle && playerVehicle == item){
 			continue;
 		}
 		//don't do stuff to mission entities
-		else if (ENTITY::IS_ENTITY_A_MISSION_ENTITY(item) && !ENTITY::DOES_ENTITY_BELONG_TO_THIS_SCRIPT(item, true))
-		{
+		else if(ENTITY::IS_ENTITY_A_MISSION_ENTITY(item) && !ENTITY::DOES_ENTITY_BELONG_TO_THIS_SCRIPT(item, true)){
 			continue;
 		}
 
@@ -738,29 +659,23 @@ std::set<Vehicle> get_nearby_vehicles(Ped playerPed)
 	return allWorldVehiclesThisFrame;
 }
 
-void cleanup_area_effects()
-{
-	for each (ENTTrackedVehicle* veh in trackedVehicles)
-	{
+void cleanup_area_effects(){
+	for each (ENTTrackedVehicle* veh in trackedVehicles){
 		delete veh;
 	}
 	trackedVehicles.clear();
 
-	for each (ENTTrackedPedestrian* ped in trackedPeds)
-	{
+	for each (ENTTrackedPedestrian* ped in trackedPeds){
 		delete ped;
 	}
 	trackedPeds.clear();
 }
 
-void kill_all_nearby_peds_now()
-{
+void kill_all_nearby_peds_now(){
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
 
-	for each (Ped xped in peds)
-	{
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+	for each (Ped xped in peds){
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(xped, true, true);
 			ENTTrackedPedestrian* trackedPed = findOrCreateTrackedPed(xped);
 			trackedPed->missionise();
@@ -778,20 +693,16 @@ void kill_all_nearby_peds_now()
 	}
 }
 
-void kill_all_nearby_peds_continuous()
-{
+void kill_all_nearby_peds_continuous(){
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
 
-	for each (Ped xped in peds)
-	{
+	for each (Ped xped in peds){
 		int chanceOfSelection = rand() % 5;
-		if (chanceOfSelection != 1)
-		{
+		if(chanceOfSelection != 1){
 			continue;
 		}
 
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(xped, true, true);
 			ENTTrackedPedestrian* trackedPed = findOrCreateTrackedPed(xped);
 			trackedPed->missionise();
@@ -809,14 +720,12 @@ void kill_all_nearby_peds_continuous()
 	}
 }
 
-void kill_all_nearby_vehicles_now()
-{
+void kill_all_nearby_vehicles_now(){
 	std::set<Vehicle> vehicles = get_nearby_vehicles(PLAYER::PLAYER_PED_ID());
 
 	set_all_nearby_vehs_to_invincible(false, true);
 
-	for each (Vehicle vehicle in vehicles)
-	{
+	for each (Vehicle vehicle in vehicles){
 		ENTITY::SET_ENTITY_AS_MISSION_ENTITY(vehicle, true, true);
 		ENTTrackedVehicle* trackedVeh = findOrCreateTrackedVehicle(vehicle);
 		trackedVeh->missionise();
@@ -825,15 +734,12 @@ void kill_all_nearby_vehicles_now()
 	}
 }
 
-void kill_all_nearby_vehicles_continuous()
-{
+void kill_all_nearby_vehicles_continuous(){
 	std::set<Vehicle> vehicles = get_nearby_vehicles(PLAYER::PLAYER_PED_ID());
 
-	for each (Vehicle vehicle in vehicles)
-	{
+	for each (Vehicle vehicle in vehicles){
 		int chanceOfBeingExploded = rand() % 5;
-		if (chanceOfBeingExploded != 1)
-		{
+		if(chanceOfBeingExploded != 1){
 			continue;
 		}
 
@@ -845,86 +751,71 @@ void kill_all_nearby_vehicles_continuous()
 	}
 }
 
-void clear_up_missionised_entitities()
-{
+void clear_up_missionised_entitities(){
 	Ped playerPed = PLAYER::PLAYER_PED_ID();
 	BOOL bPlayerExists = ENTITY::DOES_ENTITY_EXIST(playerPed);
 
 	std::deque<ENTTrackedVehicle*>::iterator vit;
-	for (vit = trackedVehicles.begin(); vit != trackedVehicles.end();)
-	{
+	for(vit = trackedVehicles.begin(); vit != trackedVehicles.end();){
 		Vehicle actualVeh = (*vit)->vehicle;
-		if (!ENTITY::DOES_ENTITY_EXIST(actualVeh) || is_entity_to_be_disposed(playerPed, actualVeh))
-		{
+		if(!ENTITY::DOES_ENTITY_EXIST(actualVeh) || is_entity_to_be_disposed(playerPed, actualVeh)){
 			delete *vit;
 			releasedVehicles.insert(actualVeh);
 			vit = trackedVehicles.erase(vit);
 		}
-		else
-		{
+		else{
 			++vit;
 		}
 	}
 
 	std::deque<ENTTrackedPedestrian*>::iterator pit;
-	for (pit = trackedPeds.begin(); pit != trackedPeds.end();)
-	{
+	for(pit = trackedPeds.begin(); pit != trackedPeds.end();){
 		Ped actualPed = (*pit)->ped;
-		if (!ENTITY::DOES_ENTITY_EXIST(actualPed)|| is_entity_to_be_disposed(playerPed, actualPed))
-		{
+		if(!ENTITY::DOES_ENTITY_EXIST(actualPed) || is_entity_to_be_disposed(playerPed, actualPed)){
 			delete *pit;
 			releasedPeds.insert(actualPed);
 			pit = trackedPeds.erase(pit);
 		}
-		else
-		{
+		else{
 			++pit;
 		}
 	}
 
 	std::set<Ped>::iterator rpIt;
-	for (rpIt = releasedPeds.begin(); rpIt != releasedPeds.end();)
-	{
-		if (!ENTITY::DOES_ENTITY_EXIST(*rpIt))
+	for(rpIt = releasedPeds.begin(); rpIt != releasedPeds.end();){
+		if(!ENTITY::DOES_ENTITY_EXIST(*rpIt)){
+			rpIt = releasedPeds.erase(rpIt);
+		}
+		else if(!is_entity_to_be_disposed(playerPed, *rpIt)) //no longer for deletion after all
 		{
 			rpIt = releasedPeds.erase(rpIt);
 		}
-		else if (!is_entity_to_be_disposed(playerPed, *rpIt)) //no longer for deletion after all
-		{
-			rpIt = releasedPeds.erase(rpIt);
-		}
-		else
-		{
+		else{
 			rpIt++;
 		}
 	}
 
 	std::set<Vehicle>::iterator rvIt;
-	for (rvIt = releasedVehicles.begin(); rvIt != releasedVehicles.end();)
-	{
-		if (!ENTITY::DOES_ENTITY_EXIST(*rvIt))
+	for(rvIt = releasedVehicles.begin(); rvIt != releasedVehicles.end();){
+		if(!ENTITY::DOES_ENTITY_EXIST(*rvIt)){
+			rvIt = releasedVehicles.erase(rvIt);
+		}
+		else if(!is_entity_to_be_disposed(playerPed, *rvIt)) //no longer for deletion after all
 		{
 			rvIt = releasedVehicles.erase(rvIt);
 		}
-		else if (!is_entity_to_be_disposed(playerPed, *rvIt)) //no longer for deletion after all
-		{
-			rvIt = releasedVehicles.erase(rvIt);
-		}
-		else
-		{
+		else{
 			rvIt++;
 		}
 	}
 }
 
-void onchange_areaeffect_ped_weapons(int value, SelectFromListMenuItem* source)
-{
+void onchange_areaeffect_ped_weapons(int value, SelectFromListMenuItem* source){
 	pedWeaponSetIndex = value;
 	pedWeaponSetUpdated = true;
 }
 
-void give_all_nearby_peds_a_weapon(bool enabled)
-{
+void give_all_nearby_peds_a_weapon(bool enabled){
 	//callsPerFrame = 0;
 
 	std::set<Ped> peds = get_nearby_peds(PLAYER::PLAYER_PED_ID());
@@ -932,44 +823,36 @@ void give_all_nearby_peds_a_weapon(bool enabled)
 	//callsA = callsPerFrame;
 	//callsPerFrame = 0;
 
-	for each (Ped xped in peds)
-	{
+	for each (Ped xped in peds){
 		int chanceOfGettingWeapon = rand() % 5;
-		if (chanceOfGettingWeapon != 1)
-		{
+		if(chanceOfGettingWeapon != 1){
 			continue;
 		}
 
-		if (!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID())))
-		{
+		if(!PED::IS_PED_GROUP_MEMBER(xped, PLAYER::GET_PLAYER_GROUP(PLAYER::PLAYER_PED_ID()))){
 			ENTTrackedPedestrian* trackedPed = findOrCreateTrackedPed(xped);
 
-			if (enabled && !trackedPed->weaponSetApplied != pedWeaponSetIndex)
-			{
+			if(enabled && !trackedPed->weaponSetApplied != pedWeaponSetIndex){
 				std::vector<std::string> weaponSet = VOV_PED_WEAPONS[pedWeaponSetIndex];
 
 				int index = rand() % weaponSet.size();
 				std::string weapon = weaponSet.at(index);
-				Hash weapHash = GAMEPLAY::GET_HASH_KEY((char *)weapon.c_str());
+				Hash weapHash = GAMEPLAY::GET_HASH_KEY((char *) weapon.c_str());
 
 				bool foundWeapon = false;
-				for (std::string searchStr : weaponSet)
-				{
-					Hash searchHash = GAMEPLAY::GET_HASH_KEY((char *)searchStr.c_str());
-					if (trackedPed->lastWeaponApplied == searchHash)
-					{
+				for(std::string searchStr : weaponSet){
+					Hash searchHash = GAMEPLAY::GET_HASH_KEY((char *) searchStr.c_str());
+					if(trackedPed->lastWeaponApplied == searchHash){
 						foundWeapon = true;
 						break;
 					}
 				}
 
-				if (!foundWeapon)
-				{
+				if(!foundWeapon){
 					WEAPON::GIVE_WEAPON_TO_PED(xped, weapHash, 9999, FALSE, TRUE);
 					WEAPON::SET_PED_INFINITE_AMMO_CLIP(xped, true);
 					PED::SET_PED_CAN_SWITCH_WEAPON(xped, true);
-					if (WEAPON::HAS_PED_GOT_WEAPON(xped, weapHash, 0) && !PED::IS_PED_IN_ANY_VEHICLE(xped, false) && !PED::IS_PED_INJURED(xped))
-					{
+					if(WEAPON::HAS_PED_GOT_WEAPON(xped, weapHash, 0) && !PED::IS_PED_IN_ANY_VEHICLE(xped, false) && !PED::IS_PED_INJURED(xped)){
 						WEAPON::SET_CURRENT_PED_WEAPON(xped, weapHash, 0);
 					}
 					trackedPed->lastWeaponApplied = weapHash;
@@ -977,8 +860,7 @@ void give_all_nearby_peds_a_weapon(bool enabled)
 
 				trackedPed->weaponSetApplied = pedWeaponSetIndex;
 			}
-			else if (!enabled && trackedPed->weaponSetApplied != 0)
-			{
+			else if(!enabled && trackedPed->weaponSetApplied != 0){
 				//TODO: take all their weapons from that set away?
 
 				trackedPed->weaponSetApplied = 0;
@@ -987,33 +869,26 @@ void give_all_nearby_peds_a_weapon(bool enabled)
 	}
 }
 
-void add_areaeffect_generic_settings(std::vector<StringPairSettingDBRow>* results)
-{
-	results->push_back(StringPairSettingDBRow{ "pedWeaponSetIndex", std::to_string(pedWeaponSetIndex) });
+void add_areaeffect_generic_settings(std::vector<StringPairSettingDBRow>* results){
+	results->push_back(StringPairSettingDBRow{"pedWeaponSetIndex", std::to_string(pedWeaponSetIndex)});
 }
 
-void handle_generic_settings_areaeffect(std::vector<StringPairSettingDBRow>* settings)
-{
-	for (int i = 0; i < settings->size(); i++)
-	{
+void handle_generic_settings_areaeffect(std::vector<StringPairSettingDBRow>* settings){
+	for(int i = 0; i < settings->size(); i++){
 		StringPairSettingDBRow setting = settings->at(i);
-		if (setting.name.compare("pedWeaponSetIndex") == 0)
-		{
+		if(setting.name.compare("pedWeaponSetIndex") == 0){
 			pedWeaponSetIndex = stoi(setting.value);
 			pedWeaponSetUpdated = true;
 		}
 	}
 }
 
-ENTTrackedPedestrian* findOrCreateTrackedPed(Ped searchPed)
-{
+ENTTrackedPedestrian* findOrCreateTrackedPed(Ped searchPed){
 	std::deque<ENTTrackedPedestrian*>::iterator pit;
-	for (pit = trackedPeds.begin(); pit != trackedPeds.end();pit++)
-	{
+	for(pit = trackedPeds.begin(); pit != trackedPeds.end(); pit++){
 		Ped queuePed = (*pit)->ped;
 
-		if (searchPed == queuePed)
-		{
+		if(searchPed == queuePed){
 			return *pit;
 		}
 	}
@@ -1024,14 +899,11 @@ ENTTrackedPedestrian* findOrCreateTrackedPed(Ped searchPed)
 	return result;
 }
 
-ENTTrackedVehicle* findOrCreateTrackedVehicle(Vehicle searchVeh)
-{
+ENTTrackedVehicle* findOrCreateTrackedVehicle(Vehicle searchVeh){
 	std::deque<ENTTrackedVehicle*>::iterator vit;
-	for (vit = trackedVehicles.begin(); vit != trackedVehicles.end(); vit++)
-	{
+	for(vit = trackedVehicles.begin(); vit != trackedVehicles.end(); vit++){
 		Vehicle queueVeh = (*vit)->vehicle;
-		if (searchVeh == queueVeh)
-		{
+		if(searchVeh == queueVeh){
 			return *vit;
 		}
 	}
@@ -1042,7 +914,6 @@ ENTTrackedVehicle* findOrCreateTrackedVehicle(Vehicle searchVeh)
 }
 
 
-bool is_entity_to_be_disposed(Ped playerPed, Entity entity)
-{
+bool is_entity_to_be_disposed(Ped playerPed, Entity entity){
 	return (!ENTITY::IS_ENTITY_ON_SCREEN(entity) && !ENTITY::HAS_ENTITY_CLEAR_LOS_TO_ENTITY(playerPed, entity, 17));
 }

--- a/EnhancedNativeTrainer/src/features/area_effect.h
+++ b/EnhancedNativeTrainer/src/features/area_effect.h
@@ -22,9 +22,8 @@ https://github.com/gtav-ent/GTAV-EnhancedNativeTrainer
 #include <set>
 #include <queue>
 
-class ENTTrackedPedestrian
-{
-public:
+class ENTTrackedPedestrian{
+	public:
 
 	Ped ped = 0;
 	bool angryApplied = false;
@@ -36,67 +35,54 @@ public:
 	bool missionised = true;
 	bool madeInvincible = false;
 
-	inline ENTTrackedPedestrian(Ped ped)
-	{
+	inline ENTTrackedPedestrian(Ped ped){
 		this->ped = ped;
 	}
 
-	inline void missionise()
-	{
+	inline void missionise(){
 		missionised = true;
-		if (ENTITY::DOES_ENTITY_EXIST(ped))
-		{
+		if(ENTITY::DOES_ENTITY_EXIST(ped)){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(ped, true, true);
 		}
 	}
 
-	inline void demissionise()
-	{
-		if (missionised && ENTITY::DOES_ENTITY_EXIST(ped))
-		{
+	inline void demissionise(){
+		if(missionised && ENTITY::DOES_ENTITY_EXIST(ped)){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(ped, false, true);
 			ENTITY::SET_ENTITY_AS_NO_LONGER_NEEDED(&ped);
 		}
 		missionised = false;
 	}
 
-	inline ~ENTTrackedPedestrian()
-	{
-		if (this->missionised)
-		{
+	inline ~ENTTrackedPedestrian(){
+		if(this->missionised){
 			demissionise();
 		}
 	}
 
-protected:
+	protected:
 
 };
 
-class ENTTrackedVehicle
-{
-public:
+class ENTTrackedVehicle{
+	public:
 
 	Vehicle vehicle;
 	bool missionised = false;
 
-	inline ENTTrackedVehicle(Vehicle vehicle)
-	{
+	inline ENTTrackedVehicle(Vehicle vehicle){
 		this->vehicle = vehicle;
 	}
 
-	inline void missionise()
-	{
+	inline void missionise(){
 		missionised = true;
-		if (ENTITY::DOES_ENTITY_EXIST(vehicle))
-		{
+		if(ENTITY::DOES_ENTITY_EXIST(vehicle)){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(vehicle, true, true);
 		}
 	}
 
-	inline void demissionise()
-	{
-		if (missionised && ENTITY::DOES_ENTITY_EXIST(vehicle))
-		{
+	inline void demissionise(){
+		if(missionised && ENTITY::DOES_ENTITY_EXIST(vehicle)){
 			ENTITY::SET_ENTITY_AS_MISSION_ENTITY(vehicle, false, true);
 			ENTITY::SET_ENTITY_AS_NO_LONGER_NEEDED(&vehicle);
 		}
@@ -104,15 +90,13 @@ public:
 	}
 
 
-	inline ~ENTTrackedVehicle()
-	{
-		if (this->missionised)
-		{
+	inline ~ENTTrackedVehicle(){
+		if(this->missionised){
 			demissionise();
 		}
 	}
 
-protected:
+	protected:
 
 };
 
@@ -126,21 +110,21 @@ const std::vector<std::vector<std::string>> VOV_PED_SKINS{ {}, PED_SKINS_ARMY, P
 
 const std::vector<std::string> PED_SKIN_TITLES{ "Unchanged", "Army", "Strippers", "Zombies" };*/
 
-const std::vector<std::string> PED_WEAPONS_MELEE{ "WEAPON_KNIFE", "WEAPON_NIGHTSTICK", "WEAPON_HAMMER", "WEAPON_BAT", "WEAPON_GOLFCLUB", "WEAPON_CROWBAR", "WEAPON_BOTTLE", "WEAPON_DAGGER", "WEAPON_HATCHET", "WEAPON_KNUCKLE", "WEAPON_MACHETE", "WEAPON_FLASHLIGHT", "WEAPON_SWITCHBLADE" };
+const std::vector<std::string> PED_WEAPONS_MELEE{"WEAPON_KNIFE", "WEAPON_NIGHTSTICK", "WEAPON_HAMMER", "WEAPON_BAT", "WEAPON_GOLFCLUB", "WEAPON_CROWBAR", "WEAPON_BOTTLE", "WEAPON_DAGGER", "WEAPON_HATCHET", "WEAPON_KNUCKLE", "WEAPON_MACHETE", "WEAPON_FLASHLIGHT", "WEAPON_SWITCHBLADE"};
 
-const std::vector<std::string> PED_WEAPONS_SMALL{ "WEAPON_PISTOL", "WEAPON_COMBATPISTOL", "WEAPON_APPISTOL", "WEAPON_PISTOL50", "WEAPON_SNSPISTOL", "WEAPON_HEAVYPISTOL", "WEAPON_VINTAGEPISTOL", "WEAPON_STUNGUN", "WEAPON_FLAREGUN", "WEAPON_MARKSMANPISTOL", "WEAPON_REVOLVER" };
+const std::vector<std::string> PED_WEAPONS_SMALL{"WEAPON_PISTOL", "WEAPON_COMBATPISTOL", "WEAPON_APPISTOL", "WEAPON_PISTOL50", "WEAPON_SNSPISTOL", "WEAPON_HEAVYPISTOL", "WEAPON_VINTAGEPISTOL", "WEAPON_STUNGUN", "WEAPON_FLAREGUN", "WEAPON_MARKSMANPISTOL", "WEAPON_REVOLVER"};
 
-const std::vector<std::string> PED_WEAPONS_RIFLES{ "WEAPON_ASSAULTRIFLE", "WEAPON_CARBINERIFLE", "WEAPON_ADVANCEDRIFLE", "WEAPON_SPECIALCARBINE", "WEAPON_COMPACTRIFLE" };
+const std::vector<std::string> PED_WEAPONS_RIFLES{"WEAPON_ASSAULTRIFLE", "WEAPON_CARBINERIFLE", "WEAPON_ADVANCEDRIFLE", "WEAPON_SPECIALCARBINE", "WEAPON_COMPACTRIFLE"};
 
-const std::vector<std::string> PED_WEAPONS_HEAVY{ "WEAPON_MINIGUN", "WEAPON_HEAVYSNIPER", "WEAPON_MG", "WEAPON_COMBATMG" };
+const std::vector<std::string> PED_WEAPONS_HEAVY{"WEAPON_MINIGUN", "WEAPON_HEAVYSNIPER", "WEAPON_MG", "WEAPON_COMBATMG"};
 
-const std::vector<std::string> PED_WEAPONS_EXPLOSIVES{ "WEAPON_GRENADELAUNCHER", "WEAPON_RPG", "WEAPON_RAILGUN", "WEAPON_HOMINGLAUNCHER", "WEAPON_GRENADE", "WEAPON_STICKYBOMB", "WEAPON_PROXMINE", "WEAPON_SMOKEGRENADE", "WEAPON_MOLOTOV" };
+const std::vector<std::string> PED_WEAPONS_EXPLOSIVES{"WEAPON_GRENADELAUNCHER", "WEAPON_RPG", "WEAPON_RAILGUN", "WEAPON_HOMINGLAUNCHER", "WEAPON_GRENADE", "WEAPON_STICKYBOMB", "WEAPON_PROXMINE", "WEAPON_SMOKEGRENADE", "WEAPON_MOLOTOV"};
 
-const std::vector<std::string> PED_WEAPONS_RANDOM{ "WEAPON_KNIFE", "WEAPON_NIGHTSTICK", "WEAPON_HAMMER", "WEAPON_BAT", "WEAPON_GOLFCLUB", "WEAPON_CROWBAR", "WEAPON_BOTTLE", "WEAPON_DAGGER", "WEAPON_HATCHET", "WEAPON_KNUCKLE", "WEAPON_MACHETE", "WEAPON_FLASHLIGHT", "WEAPON_SWITCHBLADE", "WEAPON_PISTOL", "WEAPON_COMBATPISTOL", "WEAPON_APPISTOL", "WEAPON_PISTOL50", "WEAPON_SNSPISTOL", "WEAPON_HEAVYPISTOL", "WEAPON_VINTAGEPISTOL", "WEAPON_STUNGUN", "WEAPON_FLAREGUN", "WEAPON_MARKSMANPISTOL", "WEAPON_REVOLVER", "WEAPON_ASSAULTRIFLE", "WEAPON_CARBINERIFLE", "WEAPON_ADVANCEDRIFLE", "WEAPON_SPECIALCARBINE", "WEAPON_BULLPUPRIFLE", "WEAPON_COMPACTRIFLE", "WEAPON_MINIGUN", "WEAPON_HEAVYSNIPER", "WEAPON_MG", "WEAPON_COMBATMG", "WEAPON_GRENADELAUNCHER", "WEAPON_RPG", "WEAPON_RAILGUN", "WEAPON_HOMINGLAUNCHER", "WEAPON_GRENADE", "WEAPON_STICKYBOMB", "WEAPON_PROXMINE", "WEAPON_SMOKEGRENADE", "WEAPON_MOLOTOV" };
+const std::vector<std::string> PED_WEAPONS_RANDOM{"WEAPON_KNIFE", "WEAPON_NIGHTSTICK", "WEAPON_HAMMER", "WEAPON_BAT", "WEAPON_GOLFCLUB", "WEAPON_CROWBAR", "WEAPON_BOTTLE", "WEAPON_DAGGER", "WEAPON_HATCHET", "WEAPON_KNUCKLE", "WEAPON_MACHETE", "WEAPON_FLASHLIGHT", "WEAPON_SWITCHBLADE", "WEAPON_PISTOL", "WEAPON_COMBATPISTOL", "WEAPON_APPISTOL", "WEAPON_PISTOL50", "WEAPON_SNSPISTOL", "WEAPON_HEAVYPISTOL", "WEAPON_VINTAGEPISTOL", "WEAPON_STUNGUN", "WEAPON_FLAREGUN", "WEAPON_MARKSMANPISTOL", "WEAPON_REVOLVER", "WEAPON_ASSAULTRIFLE", "WEAPON_CARBINERIFLE", "WEAPON_ADVANCEDRIFLE", "WEAPON_SPECIALCARBINE", "WEAPON_BULLPUPRIFLE", "WEAPON_COMPACTRIFLE", "WEAPON_MINIGUN", "WEAPON_HEAVYSNIPER", "WEAPON_MG", "WEAPON_COMBATMG", "WEAPON_GRENADELAUNCHER", "WEAPON_RPG", "WEAPON_RAILGUN", "WEAPON_HOMINGLAUNCHER", "WEAPON_GRENADE", "WEAPON_STICKYBOMB", "WEAPON_PROXMINE", "WEAPON_SMOKEGRENADE", "WEAPON_MOLOTOV"};
 
-const std::vector<std::vector<std::string>> VOV_PED_WEAPONS{ {}, PED_WEAPONS_MELEE, PED_WEAPONS_SMALL, PED_WEAPONS_RIFLES, PED_WEAPONS_HEAVY, PED_WEAPONS_EXPLOSIVES, PED_WEAPONS_RANDOM };
+const std::vector<std::vector<std::string>> VOV_PED_WEAPONS{{}, PED_WEAPONS_MELEE, PED_WEAPONS_SMALL, PED_WEAPONS_RIFLES, PED_WEAPONS_HEAVY, PED_WEAPONS_EXPLOSIVES, PED_WEAPONS_RANDOM};
 
-const std::vector<std::string> PED_WEAPON_TITLES{ "None (Normal)", "Melee", "Small Arms", "Rifles", "Heavy", "Explosives", "Random" };
+const std::vector<std::string> PED_WEAPON_TITLES{"None (Normal)", "Melee", "Small Arms", "Rifles", "Heavy", "Explosives", "Random"};
 
 bool onconfirm_areaeffect_ped_menu(MenuItem<int> choice);
 

--- a/EnhancedNativeTrainer/src/features/bodyguards.cpp
+++ b/EnhancedNativeTrainer/src/features/bodyguards.cpp
@@ -15,6 +15,8 @@ https://github.com/gtav-ent/GTAV-EnhancedNativeTrainer
 
 int activeLineIndexBodyguards = 0;
 
+int const BODYGUARD_LIMIT = 16;
+
 bool featureBodyguardInvincible = false;
 bool featureBodyguardInvincibleUpdated = false;
 bool featureBodyguardHelmet = false;
@@ -23,18 +25,17 @@ bool featureBodyguardInfAmmo = false;
 bool requireRefreshOfBodyguardMainMenu = false;
 
 //first index is which category, second is position in that category
-int skinTypesBodyguardMenuPositionMemory[2] = { 0, 0 };
+int skinTypesBodyguardMenuPositionMemory[2] = {0, 0};
 
 //first index is which category, second is position in that category
-int skinTypesBodyguardMenuLastConfirmed[2] = { 0, 0 };
+int skinTypesBodyguardMenuLastConfirmed[2] = {0, 0};
 
 std::vector<Ped> spawnedBodyguards;
 
 std::vector<bool *> bodyguardWeaponsToggle[8];
 bool bodyguardWeaponsToggleInitialized = false;
 
-bool process_bodyguard_skins_menu()
-{
+bool process_bodyguard_skins_menu(){
 	std::vector<MenuItem<int>*> menuItems;
 	MenuItem<int> *item;
 
@@ -53,58 +54,51 @@ bool process_bodyguard_skins_menu()
 	return draw_generic_menu<int>(menuItems, &skinTypesBodyguardMenuPositionMemory[0], "Bodyguard Skins", onconfirm_bodyguard_skins_menu, NULL, NULL);
 }
 
-bool onconfirm_bodyguard_skins_menu(MenuItem<int> choice)
-{
-	switch (choice.value)
-	{
-	case 0:
-		return process_player_skins_menu();
-	case 1:
-		return process_npc_skins_menu();
-	default:
-		break;
+bool onconfirm_bodyguard_skins_menu(MenuItem<int> choice){
+	switch(choice.value){
+		case 0:
+			return process_player_skins_menu();
+		case 1:
+			return process_npc_skins_menu();
+		default:
+			break;
 	}
 	return false;
 }
 
-std::string get_current_model_name()
-{
+std::string get_current_model_name(){
 	std::string value;
-	switch (skinTypesBodyguardMenuLastConfirmed[0])
-	{
-	case 0:
-		value = SKINS_PLAYER_CAPTIONS[skinTypesBodyguardMenuLastConfirmed[1]];
-		break;
-	case 1:
-		value = SKINS_GENERAL_CAPTIONS[skinTypesBodyguardMenuLastConfirmed[1]];
-		break;
-	default:
-		value = SKINS_GENERAL_CAPTIONS[0];
-		break;
+	switch(skinTypesBodyguardMenuLastConfirmed[0]){
+		case 0:
+			value = SKINS_PLAYER_CAPTIONS[skinTypesBodyguardMenuLastConfirmed[1]];
+			break;
+		case 1:
+			value = SKINS_GENERAL_CAPTIONS[skinTypesBodyguardMenuLastConfirmed[1]];
+			break;
+		default:
+			value = SKINS_GENERAL_CAPTIONS[0];
+			break;
 	}
 	return value;
 }
 
-Hash get_current_model_hash()
-{
+Hash get_current_model_hash(){
 	std::string value;
-	switch (skinTypesBodyguardMenuLastConfirmed[0])
-	{
-	case 0:
-		value = SKINS_PLAYER_VALUES[skinTypesBodyguardMenuLastConfirmed[1]];
-		break;
-	case 1:
-		value = SKINS_GENERAL_VALUES[skinTypesBodyguardMenuLastConfirmed[1]];
-		break;
-	default:
-		value = SKINS_GENERAL_VALUES[0];
-		break;
+	switch(skinTypesBodyguardMenuLastConfirmed[0]){
+		case 0:
+			value = SKINS_PLAYER_VALUES[skinTypesBodyguardMenuLastConfirmed[1]];
+			break;
+		case 1:
+			value = SKINS_GENERAL_VALUES[skinTypesBodyguardMenuLastConfirmed[1]];
+			break;
+		default:
+			value = SKINS_GENERAL_VALUES[0];
+			break;
 	}
-	return GAMEPLAY::GET_HASH_KEY((char*)value.c_str());
+	return GAMEPLAY::GET_HASH_KEY((char*) value.c_str());
 }
 
-bool onconfirm_bodyguards_skins_players(MenuItem<std::string> choice)
-{
+bool onconfirm_bodyguards_skins_players(MenuItem<std::string> choice){
 	skinTypesBodyguardMenuPositionMemory[0] = 0;
 	skinTypesBodyguardMenuPositionMemory[1] = choice.currentMenuIndex;
 	skinTypesBodyguardMenuLastConfirmed[0] = 0;
@@ -114,8 +108,7 @@ bool onconfirm_bodyguards_skins_players(MenuItem<std::string> choice)
 	return true;
 }
 
-bool onconfirm_bodyguards_skins_npcs(MenuItem<std::string> choice)
-{
+bool onconfirm_bodyguards_skins_npcs(MenuItem<std::string> choice){
 	skinTypesBodyguardMenuPositionMemory[0] = 1;
 	skinTypesBodyguardMenuPositionMemory[1] = choice.currentMenuIndex;
 	skinTypesBodyguardMenuLastConfirmed[0] = 1;
@@ -126,11 +119,9 @@ bool onconfirm_bodyguards_skins_npcs(MenuItem<std::string> choice)
 	return true;
 }
 
-bool process_player_skins_menu()
-{
+bool process_player_skins_menu(){
 	std::vector<MenuItem<std::string>*> menuItems;
-	for (int i = 0; i < SKINS_PLAYER_CAPTIONS.size(); i++)
-	{
+	for(int i = 0; i < SKINS_PLAYER_CAPTIONS.size(); i++){
 		MenuItem<std::string> *item = new MenuItem<std::string>();
 		item->caption = SKINS_PLAYER_CAPTIONS[i];
 		item->value = SKINS_PLAYER_VALUES[i];
@@ -141,11 +132,9 @@ bool process_player_skins_menu()
 	return draw_generic_menu<std::string>(menuItems, &skinTypesBodyguardMenuPositionMemory[1], "Player Skins", onconfirm_bodyguards_skins_players, NULL, NULL);
 }
 
-bool process_npc_skins_menu()
-{
+bool process_npc_skins_menu(){
 	std::vector<MenuItem<std::string>*> menuItems;
-	for (int i = 0; i < SKINS_GENERAL_CAPTIONS.size(); i++)
-	{
+	for(int i = 0; i < SKINS_GENERAL_CAPTIONS.size(); i++){
 		MenuItem<std::string> *item = new MenuItem<std::string>();
 		item->caption = SKINS_GENERAL_CAPTIONS[i];
 		item->value = SKINS_GENERAL_VALUES[i];
@@ -156,12 +145,35 @@ bool process_npc_skins_menu()
 	return draw_generic_menu<std::string>(menuItems, &skinTypesBodyguardMenuPositionMemory[1], "NPC Skins", onconfirm_bodyguards_skins_npcs, NULL, NULL);
 }
 
+bool onconfirm_bodyguard_weapons_category_menu(MenuItem<int> choice){
+	switch(choice.value){
+		case 0:
+			for(int a = 0; a < VOV_WEAPON_CAPTIONS[choice.sortval].size(); a++){
+				*bodyguardWeaponsToggle[choice.sortval].at(a) = !*bodyguardWeaponsToggle[choice.sortval].at(a);
+			}
+			set_status_text(std::string("All bodyguard ") + MENU_WEAPON_CATEGORIES.at(choice.sortval) + std::string(" weapons toggled"));
+			break;
+		default:
+			break;
+	}
+
+	return false;
+}
+
 bool process_bodyguard_weapons_category_menu(int category){
 	std::vector<MenuItem<int> *> menuItems;
+	MenuItem<int> *item;
 	ToggleMenuItem<int> *toggleItem;
 	int index = 0;
 
-	for(auto a: VOV_WEAPON_CAPTIONS[category]){
+	item = new MenuItem<int>();
+	item->caption = "Toggle All Weapons in Category";
+	item->value = index++;
+	item->isLeaf = true;
+	item->sortval = category;
+	menuItems.push_back(item);
+
+	for(auto a : VOV_WEAPON_CAPTIONS[category]){
 		toggleItem = new ToggleMenuItem<int>();
 		toggleItem->caption = a;
 		toggleItem->value = index;
@@ -181,7 +193,7 @@ bool onconfirm_bodyguard_weapons_menu(MenuItem<int> choice){
 	else if(choice.value == cs){
 		for(int a = 0; a < cs; a++){
 			for(int b = 0; b < VOV_WEAPON_VALUES[a].size(); b++){
-				*(bodyguardWeaponsToggle[a].at(b)) = true;
+				*bodyguardWeaponsToggle[a].at(b) = true;
 			}
 		}
 		set_status_text("All bodyguard weapons enabled");
@@ -189,7 +201,7 @@ bool onconfirm_bodyguard_weapons_menu(MenuItem<int> choice){
 	else if(choice.value == cs + 1){
 		for(int a = 0; a < cs; a++){
 			for(int b = 0; b < VOV_WEAPON_VALUES[a].size(); b++){
-				*(bodyguardWeaponsToggle[a].at(b)) = false;
+				*bodyguardWeaponsToggle[a].at(b) = false;
 			}
 		}
 		set_status_text("All bodyguard weapons disabled");
@@ -203,7 +215,7 @@ bool process_bodyguard_weapons_menu(){
 	MenuItem<int> *item;
 	int index = 0;
 
-	for(auto a: MENU_WEAPON_CATEGORIES){
+	for(auto a : MENU_WEAPON_CATEGORIES){
 		item = new MenuItem<int>();
 		item->caption = a;
 		item->value = index++;
@@ -226,15 +238,14 @@ bool process_bodyguard_weapons_menu(){
 	return draw_generic_menu<int>(menuItems, nullptr, "Choose Bodyguard Weapons", onconfirm_bodyguard_weapons_menu, nullptr, nullptr, nullptr);
 }
 
-void dismiss_bodyguards() {
+void dismiss_bodyguards(){
 
-	if (spawnedBodyguards.size() == 0) {
+	if(spawnedBodyguards.size() == 0){
 		set_status_text("You don't have any bodyguards");
 		return;
 	}
 
-	for (int i = 0; i < spawnedBodyguards.size(); i++)
-	{
+	for(int i = 0; i < spawnedBodyguards.size(); i++){
 		ENTITY::SET_ENTITY_INVINCIBLE(spawnedBodyguards[i], false);
 		PED::REMOVE_PED_FROM_GROUP(spawnedBodyguards[i]);
 		AI::CLEAR_PED_TASKS(spawnedBodyguards[i]);
@@ -246,23 +257,20 @@ void dismiss_bodyguards() {
 	set_status_text("Bodyguards dismissed");
 }
 
-void do_spawn_bodyguard() {
+void do_spawn_bodyguard(){
 
 	requireRefreshOfBodyguardMainMenu = true;
 
-	if (spawnedBodyguards.size() >= 7)
-	{
+	if(spawnedBodyguards.size() >= BODYGUARD_LIMIT){
 		set_status_text("Cannot spawn any more bodyguards");
 		return;
 	}
 
 	DWORD bodyGuardModel = get_current_model_hash();
 
-	if (STREAMING::IS_MODEL_IN_CDIMAGE(bodyGuardModel) && STREAMING::IS_MODEL_VALID(bodyGuardModel))
-	{
+	if(STREAMING::IS_MODEL_IN_CDIMAGE(bodyGuardModel) && STREAMING::IS_MODEL_VALID(bodyGuardModel)){
 		STREAMING::REQUEST_MODEL(bodyGuardModel);
-		while (!STREAMING::HAS_MODEL_LOADED(bodyGuardModel))
-		{
+		while(!STREAMING::HAS_MODEL_LOADED(bodyGuardModel)){
 			make_periodic_feature_call();
 			WAIT(0);
 		}
@@ -278,13 +286,11 @@ void do_spawn_bodyguard() {
 		PED::SET_PED_AS_GROUP_MEMBER(bodyGuard, myGroup);
 		PED::SET_PED_NEVER_LEAVES_GROUP(bodyGuard, true);
 
-		if (featureBodyguardInvincible)
-		{
+		if(featureBodyguardInvincible){
 			ENTITY::SET_ENTITY_INVINCIBLE(bodyGuard, true);
 		}
 
-		if (featureBodyguardHelmet)
-		{
+		if(featureBodyguardHelmet){
 			PED::GIVE_PED_HELMET(bodyGuard, 1, 4096, -1);
 		}
 
@@ -296,14 +302,13 @@ void do_spawn_bodyguard() {
 				if(*bodyguardWeaponsToggle[a].at(b)){
 					Hash tmp = GAMEPLAY::GET_HASH_KEY((char *) VOV_WEAPON_VALUES[a].at(b).c_str());
 					if(!WEAPON::HAS_PED_GOT_WEAPON(bodyGuard, tmp, false)){
-						WEAPON::GIVE_WEAPON_TO_PED(bodyGuard, tmp, 9999, false, true);
+						WEAPON::GIVE_WEAPON_TO_PED(bodyGuard, tmp, 100, false, true);
 					}
 				}
 			}
 		}
 
-		if (featureBodyguardInfAmmo)
-		{
+		if(featureBodyguardInfAmmo){
 			WEAPON::SET_PED_INFINITE_AMMO_CLIP(bodyGuard, true);
 		}
 
@@ -313,13 +318,14 @@ void do_spawn_bodyguard() {
 		PED::SET_PED_DEFAULT_COMPONENT_VARIATION(bodyGuard);
 		WAIT(0);
 
-		if (PED::IS_PED_IN_ANY_VEHICLE(PLAYER::PLAYER_PED_ID(), 0)) {
+		if(PED::IS_PED_IN_ANY_VEHICLE(PLAYER::PLAYER_PED_ID(), 0)){
 			Vehicle veh = PED::GET_VEHICLE_PED_IS_USING(PLAYER::PLAYER_PED_ID());
 
-			for (int i = 0; i <= VEHICLE::GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(veh) - 1; i++) {
-				if (VEHICLE::IS_VEHICLE_SEAT_FREE(veh, i)) {
-					AI::TASK_WARP_PED_INTO_VEHICLE(bodyGuard, veh, i); break;
-					PED::SET_PED_INTO_VEHICLE(bodyGuard, veh, i);
+			for(int i = 0; i < VEHICLE::GET_VEHICLE_MAX_NUMBER_OF_PASSENGERS(veh); i++){
+				if(VEHICLE::IS_VEHICLE_SEAT_FREE(veh, i)){
+					AI::TASK_WARP_PED_INTO_VEHICLE(bodyGuard, veh, i);
+					//PED::SET_PED_INTO_VEHICLE(bodyGuard, veh, i);
+					break;
 				}
 			}
 		}
@@ -330,29 +336,23 @@ void do_spawn_bodyguard() {
 	return;
 }
 
-void maintain_bodyguards()
-{
+void maintain_bodyguards(){
 	std::vector<Ped>::iterator iter = spawnedBodyguards.begin();
 
-	while (iter != spawnedBodyguards.end())
-	{
-		if (PED::IS_PED_DEAD_OR_DYING(*iter, true))
-		{
+	while(iter != spawnedBodyguards.end()){
+		if(PED::IS_PED_DEAD_OR_DYING(*iter, true)){
 			// clean up PED stuff, for now let's assume the game handles everything and we just worry about our vector
 			iter = spawnedBodyguards.erase(iter);
 			requireRefreshOfBodyguardMainMenu = true;
 		}
-		else
-		{
+		else{
 			++iter;
 		}
 	}
 }
 
-bool process_bodyguard_menu()
-{
-	do
-	{
+bool process_bodyguard_menu(){
+	do{
 		requireRefreshOfBodyguardMainMenu = false;
 		int i = 0;
 
@@ -420,91 +420,76 @@ bool process_bodyguard_menu()
 
 		draw_generic_menu<int>(menuItems, &activeLineIndexBodyguards, caption, onconfirm_bodyguard_menu, NULL, NULL, bodyguards_main_menu_interrupt);
 	}
-	while (requireRefreshOfBodyguardMainMenu);
+	while(requireRefreshOfBodyguardMainMenu);
 	return false;
 }
 
-bool onconfirm_bodyguard_menu(MenuItem<int> choice)
-{
+bool onconfirm_bodyguard_menu(MenuItem<int> choice){
 	// common variables
 	BOOL bPlayerExists = ENTITY::DOES_ENTITY_EXIST(PLAYER::PLAYER_PED_ID());
 	Player player = PLAYER::PLAYER_ID();
 	Ped playerPed = PLAYER::PLAYER_PED_ID();
 
-	switch (choice.value)
-	{
-	case 0:
-		do_spawn_bodyguard();
-		break;
-	case 1:
-		dismiss_bodyguards();
-		break;
-	case 2:
-		process_bodyguard_skins_menu();
-		break;
-	case 3:
-		process_bodyguard_weapons_menu();
-		break;
-	default:
-		break;
+	switch(choice.value){
+		case 0:
+			do_spawn_bodyguard();
+			break;
+		case 1:
+			dismiss_bodyguards();
+			break;
+		case 2:
+			process_bodyguard_skins_menu();
+			break;
+		case 3:
+			process_bodyguard_weapons_menu();
+			break;
+		default:
+			break;
 	}
 	return false;
 }
 
-void update_bodyguard_features()
-{
-	if (featureBodyguardInvincibleUpdated)
-	{
-		for (int i = 0; i < spawnedBodyguards.size(); i++)
-		{
+void update_bodyguard_features(){
+	if(featureBodyguardInvincibleUpdated){
+		for(int i = 0; i < spawnedBodyguards.size(); i++){
 			ENTITY::SET_ENTITY_INVINCIBLE(spawnedBodyguards[i], featureBodyguardInvincible);
 		}
 	}
 }
 
-void add_bodyguards_feature_enablements(std::vector<FeatureEnabledLocalDefinition>* results)
-{
-	results->push_back(FeatureEnabledLocalDefinition{ "featureBodyguardInvincible", &featureBodyguardInvincible });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureBodyguardHelmet", &featureBodyguardHelmet });
-	results->push_back(FeatureEnabledLocalDefinition{ "featureBodyguardInfAmmo", &featureBodyguardInfAmmo });
+void add_bodyguards_feature_enablements(std::vector<FeatureEnabledLocalDefinition>* results){
+	results->push_back(FeatureEnabledLocalDefinition{"featureBodyguardInvincible", &featureBodyguardInvincible});
+	results->push_back(FeatureEnabledLocalDefinition{"featureBodyguardHelmet", &featureBodyguardHelmet});
+	results->push_back(FeatureEnabledLocalDefinition{"featureBodyguardInfAmmo", &featureBodyguardInfAmmo});
 }
 
-void add_bodyguards_generic_settings(std::vector<StringPairSettingDBRow>* results)
-{
-	results->push_back(StringPairSettingDBRow{ "skinTypesBodyguardMenuPositionMemory0", std::to_string(skinTypesBodyguardMenuPositionMemory[0]) });
-	results->push_back(StringPairSettingDBRow{ "skinTypesBodyguardMenuPositionMemory1", std::to_string(skinTypesBodyguardMenuPositionMemory[1]) });
-	results->push_back(StringPairSettingDBRow{ "skinTypesBodyguardMenuLastConfirmed0", std::to_string(skinTypesBodyguardMenuLastConfirmed[0]) });
-	results->push_back(StringPairSettingDBRow{ "skinTypesBodyguardMenuLastConfirmed1", std::to_string(skinTypesBodyguardMenuLastConfirmed[1]) });
+void add_bodyguards_generic_settings(std::vector<StringPairSettingDBRow>* results){
+	results->push_back(StringPairSettingDBRow{"skinTypesBodyguardMenuPositionMemory0", std::to_string(skinTypesBodyguardMenuPositionMemory[0])});
+	results->push_back(StringPairSettingDBRow{"skinTypesBodyguardMenuPositionMemory1", std::to_string(skinTypesBodyguardMenuPositionMemory[1])});
+	results->push_back(StringPairSettingDBRow{"skinTypesBodyguardMenuLastConfirmed0", std::to_string(skinTypesBodyguardMenuLastConfirmed[0])});
+	results->push_back(StringPairSettingDBRow{"skinTypesBodyguardMenuLastConfirmed1", std::to_string(skinTypesBodyguardMenuLastConfirmed[1])});
 }
 
-void handle_generic_settings_bodyguards(std::vector<StringPairSettingDBRow>* settings)
-{
-	for (int i = 0; i < settings->size(); i++)
-	{
+void handle_generic_settings_bodyguards(std::vector<StringPairSettingDBRow>* settings){
+	for(int i = 0; i < settings->size(); i++){
 		StringPairSettingDBRow setting = settings->at(i);
-		if (setting.name.compare("skinTypesBodyguardMenuPositionMemory0") == 0)
-		{
+		if(setting.name.compare("skinTypesBodyguardMenuPositionMemory0") == 0){
 			skinTypesBodyguardMenuPositionMemory[0] = stoi(setting.value);
 		}
-		else if (setting.name.compare("skinTypesBodyguardMenuPositionMemory1") == 0)
-		{
+		else if(setting.name.compare("skinTypesBodyguardMenuPositionMemory1") == 0){
 			skinTypesBodyguardMenuPositionMemory[1] = stoi(setting.value);
 		}
-		else if (setting.name.compare("skinTypesBodyguardMenuLastConfirmed0") == 0)
-		{
+		else if(setting.name.compare("skinTypesBodyguardMenuLastConfirmed0") == 0){
 			skinTypesBodyguardMenuLastConfirmed[0] = stoi(setting.value);
 		}
-		else if (setting.name.compare("skinTypesBodyguardMenuLastConfirmed1") == 0)
-		{
+		else if(setting.name.compare("skinTypesBodyguardMenuLastConfirmed1") == 0){
 			skinTypesBodyguardMenuLastConfirmed[1] = stoi(setting.value);
 		}
 	}
 }
 
-bool bodyguards_main_menu_interrupt()
-{
-	if (requireRefreshOfBodyguardMainMenu)
-	{
+bool bodyguards_main_menu_interrupt(){
+	if(requireRefreshOfBodyguardMainMenu){
 		return true;
 	}
 	return false;

--- a/EnhancedNativeTrainer/src/features/script.cpp
+++ b/EnhancedNativeTrainer/src/features/script.cpp
@@ -194,7 +194,7 @@ void update_features(){
 		game_frame_num = 0;
 	}
 
-	if(game_frame_num % 1000 == 0){
+	if(game_frame_num % 3600 == 0){
 		DWORD myThreadID;
 		HANDLE myHandle = CreateThread(0, 0, save_settings_thread, 0, 0, &myThreadID);
 		CloseHandle(myHandle);
@@ -837,8 +837,12 @@ void ScriptTidyUp(){
 
 		write_text_to_log_file("ScriptTidyUp called");
 
+		save_settings();
+		write_text_to_log_file("Saved settings");
+
 		setGameInputToEnabled(true, true);
 		setAirbrakeRelatedInputToBlocked(false, true);
+		write_text_to_log_file("Reset input");
 
 		cleanup_script();
 		write_text_to_log_file("Cleaned up script");
@@ -848,9 +852,6 @@ void ScriptTidyUp(){
 		WAIT(0);
 		cleanup_anims();
 		write_text_to_log_file("Cleaned up anims");
-
-		save_settings();
-		write_text_to_log_file("Saved settings");
 
 		end_xinput();
 		write_text_to_log_file("XInput terminated");

--- a/EnhancedNativeTrainer/src/features/vehicles.cpp
+++ b/EnhancedNativeTrainer/src/features/vehicles.cpp
@@ -727,8 +727,8 @@ void reset_vehicle_globals(){
 }
 
 bool onconfirm_carspawn_menu(MenuItem<int> choice){
-	if(choice.value == MENU_VEHICLE_CATEGORIES.size() - 1) //custom spawn
-	{
+	if(choice.value == MENU_VEHICLE_CATEGORIES.size() - 1){
+		// custom spawn
 		std::string result = show_keyboard(NULL, (char*) lastCustomVehicleSpawn.c_str());
 		if(!result.empty()){
 			result = trim(result);
@@ -1286,13 +1286,13 @@ bool process_savedveh_menu(){
 					item->sortval = sv->rowID;
 					break;
 				case 1:
-					item->sortval = NULL;
+					item->sortval = 0;
 					break;
 				case 2:
 					item->sortval = VEHICLE::GET_VEHICLE_CLASS_FROM_NAME(sv->model);
 					break;
 				default:
-					item->sortval = NULL;
+					item->sortval = 0;
 					break;
 			}
 			menuItems.push_back(item);

--- a/EnhancedNativeTrainer/src/features/weapons.h
+++ b/EnhancedNativeTrainer/src/features/weapons.h
@@ -212,8 +212,6 @@ void fill_weapon_ammo(MenuItem<int> choice);
 
 void onconfirm_open_tint_menu(MenuItem<int> choice);
 
-bool process_weapon_mod_menu_tint();
-
 //Weapon mod menu
 
 bool process_weapon_mod_menu_tint();


### PR DESCRIPTION
Minor
- Additions
  - Added the option to never have parachutes.
    - Mutually exclusive with the infinite parachutes option: turning one on will turn the other off.
- Changes
  - Increased the maximum number of bodyguards.
    - Also turned the limit into a constant variable for easier access.
  - Giving all weapons, filling all ammo, or adding parachutes will also give a reserve parachute.